### PR TITLE
SIM Group and SIM(s) are made as OPTIONAL attributes for 5G full deployment

### DIFF
--- a/quickstarts/microsoft.mobilenetwork/mobilenetwork-create-full-5gc-deployment/azuredeploy.json
+++ b/quickstarts/microsoft.mobilenetwork/mobilenetwork-create-full-5gc-deployment/azuredeploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.8.2.30886",
-      "templateHash": "1206758085608647660"
+      "version": "0.8.9.13224",
+      "templateHash": "8292831102031834016"
     }
   },
   "parameters": {
@@ -45,7 +45,7 @@
     },
     "serviceName": {
       "type": "string",
-      "defaultValue": "Allow_all_traffic",
+      "defaultValue": "Allow-all-traffic",
       "metadata": {
         "description": "The name of the service"
       }
@@ -66,12 +66,14 @@
     },
     "simGroupName": {
       "type": "string",
+      "defaultValue": "",
       "metadata": {
         "description": "The name for the SIM group."
       }
     },
     "simResources": {
       "type": "array",
+      "defaultValue": [],
       "metadata": {
         "description": "An array containing properties of the SIM(s) you wish to create. See [Provision proxy SIM(s)](https://docs.microsoft.com/en-gb/azure/private-5g-core/provision-sims-azure-portal) for a full description of the required properties and their format."
       }
@@ -208,13 +210,14 @@
       ]
     },
     {
+      "condition": "[not(empty(parameters('simGroupName')))]",
       "copy": {
         "name": "exampleSimResources",
         "count": "[length(parameters('simResources'))]"
       },
       "type": "Microsoft.MobileNetwork/simGroups/sims",
       "apiVersion": "2022-04-01-preview",
-      "name": "[format('{0}/{1}', parameters('simGroupName'), parameters('simResources')[copyIndex()].simName)]",
+      "name": "[format('{0}/{1}', if(empty(parameters('simGroupName')), 'placeHolderForValidation', parameters('simGroupName')), parameters('simResources')[copyIndex()].simName)]",
       "properties": {
         "integratedCircuitCardIdentifier": "[parameters('simResources')[copyIndex()].integratedCircuitCardIdentifier]",
         "internationalMobileSubscriberIdentity": "[parameters('simResources')[copyIndex()].internationalMobileSubscriberIdentity]",
@@ -226,7 +229,7 @@
         }
       },
       "dependsOn": [
-        "[resourceId('Microsoft.MobileNetwork/simGroups', parameters('simGroupName'))]",
+        "[resourceId('Microsoft.MobileNetwork/simGroups', if(empty(parameters('simGroupName')), 'placeHolderForValidation', parameters('simGroupName')))]",
         "[resourceId('Microsoft.MobileNetwork/mobileNetworks/simPolicies', parameters('mobileNetworkName'), parameters('simPolicyName'))]"
       ]
     },
@@ -314,7 +317,7 @@
         "servicePrecedence": 253,
         "pccRules": [
           {
-            "ruleName": "All_traffic",
+            "ruleName": "All-traffic",
             "rulePrecedence": 253,
             "trafficControl": "Enabled",
             "serviceDataFlowTemplates": [
@@ -384,9 +387,10 @@
       ]
     },
     {
+      "condition": "[not(empty(parameters('simGroupName')))]",
       "type": "Microsoft.MobileNetwork/simGroups",
       "apiVersion": "2022-04-01-preview",
-      "name": "[parameters('simGroupName')]",
+      "name": "[if(empty(parameters('simGroupName')), 'placeHolderForValidation', parameters('simGroupName'))]",
       "location": "[parameters('location')]",
       "properties": {
         "mobileNetwork": {

--- a/quickstarts/microsoft.mobilenetwork/mobilenetwork-create-full-5gc-deployment/azuredeploy.parameters.json
+++ b/quickstarts/microsoft.mobilenetwork/mobilenetwork-create-full-5gc-deployment/azuredeploy.parameters.json
@@ -18,7 +18,7 @@
             "value": "GEN-UNIQUE"
         },
         "serviceName": {
-            "value": "Allow_all_traffic"
+            "value": "Allow-all-traffic"
         },
         "simPolicyName": {
             "value": "Default-policy"

--- a/quickstarts/microsoft.mobilenetwork/mobilenetwork-create-full-5gc-deployment/main.bicep
+++ b/quickstarts/microsoft.mobilenetwork/mobilenetwork-create-full-5gc-deployment/main.bicep
@@ -14,7 +14,7 @@ param mobileNetworkCode string = '01'
 param siteName string = 'myExampleSite'
 
 @description('The name of the service')
-param serviceName string = 'Allow_all_traffic'
+param serviceName string = 'Allow-all-traffic'
 
 @description('The name of the SIM policy')
 param simPolicyName string = 'Default-policy'
@@ -23,10 +23,10 @@ param simPolicyName string = 'Default-policy'
 param sliceName string = 'slice-1'
 
 @description('The name for the SIM group.')
-param simGroupName string
+param simGroupName string = ''
 
 @description('An array containing properties of the SIM(s) you wish to create. See [Provision proxy SIM(s)](https://docs.microsoft.com/en-gb/azure/private-5g-core/provision-sims-azure-portal) for a full description of the required properties and their format.')
-param simResources array
+param simResources array = []
 
 @description('The name of the control plane interface on the access network. In 5G networks this is called the N2 interface whereas in 4G networks this is called the S1-MME interface. This should match one of the interfaces configured on your Azure Stack Edge machine.')
 param controlPlaneAccessInterfaceName string = ''
@@ -132,7 +132,7 @@ resource exampleService 'Microsoft.MobileNetwork/mobileNetworks/services@2022-04
     servicePrecedence: 253
     pccRules: [
       {
-        ruleName: 'All_traffic'
+        ruleName: 'All-traffic'
         rulePrecedence: 253
         trafficControl: 'Enabled'
         serviceDataFlowTemplates: [
@@ -193,8 +193,8 @@ resource exampleSimPolicy 'Microsoft.MobileNetwork/mobileNetworks/simPolicies@20
   }
 }
 
-resource exampleSimGroupResource 'Microsoft.MobileNetwork/simGroups@2022-04-01-preview' = {
-  name: simGroupName
+resource exampleSimGroupResource 'Microsoft.MobileNetwork/simGroups@2022-04-01-preview' = if (!empty(simGroupName)) {
+  name: empty(simGroupName) ? 'placeHolderForValidation' : simGroupName
   location: location
   properties: {
     mobileNetwork: {

--- a/quickstarts/microsoft.mobilenetwork/mobilenetwork-provision-proxy-sims/prereqs/prereq.azuredeploy.json
+++ b/quickstarts/microsoft.mobilenetwork/mobilenetwork-provision-proxy-sims/prereqs/prereq.azuredeploy.json
@@ -51,7 +51,7 @@
     },
     "serviceName": {
       "type": "string",
-      "defaultValue": "Allow_all_traffic",
+      "defaultValue": "Allow-all-traffic",
       "metadata": {
         "description": "The name of the service"
       }
@@ -110,7 +110,7 @@
         "servicePrecedence": 253,
         "pccRules": [
           {
-            "ruleName": "All_traffic",
+            "ruleName": "All-traffic",
             "rulePrecedence": 253,
             "trafficControl": "Enabled",
             "serviceDataFlowTemplates": [


### PR DESCRIPTION
SIM Group and SIM(s) are made as OPTIONAL attributes for 5G full deployment

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [ ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* SIM Group and SIM(s) are made as OPTIONAL attributes for 5G full deployment
